### PR TITLE
Fix to not strip url if no opts.url is specified

### DIFF
--- a/src/angular-plupload.js
+++ b/src/angular-plupload.js
@@ -44,7 +44,7 @@
           /* jshint camelcase: false */
           link: function postLink(scope, element, attrs) {
             var opts = pluploadOption;
-            opts.url = scope.url;
+            opts.url = scope.url || opts.url;
             /* jshint unused: false */
             opts.browse_button = element[0];
             angular.extend(opts, scope.options);


### PR DESCRIPTION
Hey mate, we're trying to get the url configured for our entire site using .configure on the provider which you conveniently exposed setOptions for.

This pull request will maintain the existing behavior if url is set on the directive anyway.

Cheers!